### PR TITLE
[NO STORY] fixed documentation using 'as' word in lowercase

### DIFF
--- a/Resources/doc/CONFIGURE.md
+++ b/Resources/doc/CONFIGURE.md
@@ -12,7 +12,7 @@ ConsoleNode
 namespace AppBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
-use MadrakIO\PersistentCommandBundle\Entity\ConsoleNode AS BaseConsoleNode;
+use MadrakIO\PersistentCommandBundle\Entity\ConsoleNode as BaseConsoleNode;
 use MadrakIO\PersistentCommandBundle\Entity\ConsoleNodeInterface;
 
 /**
@@ -41,7 +41,7 @@ ConsoleNodeProcess
 namespace AppBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
-use MadrakIO\PersistentCommandBundle\Entity\ConsoleNodeProcess AS BaseConsoleNodeProcess;
+use MadrakIO\PersistentCommandBundle\Entity\ConsoleNodeProcess as BaseConsoleNodeProcess;
 use MadrakIO\PersistentCommandBundle\Entity\ConsoleNodeProcessInterface;
 
 /**
@@ -59,7 +59,7 @@ class ConsoleNodeProcess extends BaseConsoleNodeProcess implements ConsoleNodePr
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="AUTO")
      */
-    protected $id;    
+    protected $id;
 }
 ```
 


### PR DESCRIPTION
```
PHP keywords must be lowercase; expected "as" but found "AS"
```

Issue found on Codeclimate. Great job on this bundle, @johnmadrak ! :)

<img width="956" alt="screenshot 2016-02-19 15 36 49" src="https://cloud.githubusercontent.com/assets/199867/13185222/b91bf332-d71e-11e5-9d4e-9fcf556cbbce.png">
